### PR TITLE
fix(countdown): Ensure correct digit count in animation

### DIFF
--- a/script.js
+++ b/script.js
@@ -143,19 +143,19 @@ function animateHeartbeat(id) {
 // Animates individual digits within a time unit (days, hours, etc.)
 // to provide a smooth visual update when numbers change.
 function animateDigits(id, value) {
+  // Duration for the exit animation of a digit.
+  const DIGIT_EXIT_ANIMATION_DURATION = 300; // ms
+
   const el = document.getElementById(id);
   const prevSpans = Array.from(el.querySelectorAll(".animated-digit"));
-  // Ensure the new value string is padded to match the expected number of digits.
-  const valueStr = value
-    .toString()
-    .padStart(prevSpans.length || value.length, "0");
+  const valueStr = value.toString();
 
   // Remove extra spans if new value is shorter
   while (prevSpans.length > valueStr.length) {
     const span = prevSpans.pop();
     span.classList.add("exit");
     requestAnimationFrame(() => span.classList.add("exit-active"));
-    setTimeout(() => span.remove(), 300);
+    setTimeout(() => span.remove(), DIGIT_EXIT_ANIMATION_DURATION);
   }
 
   // Iterate over each character (digit) in the new value string.
@@ -189,7 +189,7 @@ function animateDigits(id, value) {
           el.appendChild(newSpan);
         }
         requestAnimationFrame(() => newSpan.classList.add("enter-active"));
-      }, 300);
+      }, DIGIT_EXIT_ANIMATION_DURATION);
     }
     // If the digit is the same as before, do nothing and keep the existing span.
   }

--- a/styles.css
+++ b/styles.css
@@ -19,7 +19,6 @@ body {
   border-radius: 20px;
   box-shadow: 0 8px 32px 0 rgba(31, 38, 135, 0.37);
   width: 75vw;
-  max-width: 700px;
   min-width: 260px;
   max-height: 90vh;
   overflow: auto;
@@ -53,8 +52,7 @@ h1 {
   color: #e5f4e3;
   font-size: clamp(1.2em, 4vw, 2.2em);
   transition: background 1.5s, color 1.5s, transform 0.2s;
-  width: 100%;
-  max-width: 320px;
+  width: 90%;
   min-width: 120px;
 }
 


### PR DESCRIPTION
Fixes #1 
This PR resolves a bug in the ```animateDigits``` function in ```script.js```, where the countdown timer could generate more ```<span class="animated-digit">``` elements than necessary for a given time unit (e.g., displaying three spans for seconds instead of two).